### PR TITLE
Add ability to put monitor to sleep like OS X

### DIFF
--- a/HotCornersApp/MainWindow.xaml
+++ b/HotCornersApp/MainWindow.xaml
@@ -13,6 +13,7 @@
         <x:Array x:Key="ComboBoxItems" Type="sys:String">
             <sys:String>No Selection</sys:String>
             <sys:String>Lock Screen</sys:String>
+            <sys:String>Put Monitor to Sleep</sys:String>
             <sys:String>Show Desktop</sys:String>
             <sys:String>Task View</sys:String>
             <sys:String>Keyboard Shortcut</sys:String>

--- a/HotCornersApp/MainWindow.xaml.cs
+++ b/HotCornersApp/MainWindow.xaml.cs
@@ -18,13 +18,21 @@ using System.Runtime.InteropServices;
 using WindowsInput.Native;
 using System.IO;
 using System.Diagnostics;
+using System.Windows.Interop;
 
 namespace HotCornersApp {
     public partial class MainWindow : Window {
+        private int SC_MONITORPOWER = 0xF170;
+        private uint WM_SYSCOMMAND = 0x0112;
+
         private NotifyIcon ni;
         private WindowsInput.InputSimulator kb = new WindowsInput.InputSimulator();
         [DllImport("user32.dll", SetLastError = true)]
         static extern bool LockWorkStation();
+
+        [DllImport("user32.dll")]
+        static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+
         public MainWindow() {
             InitializeComponent();
             checkBox2.IsChecked = Properties.Settings.Default.runOnStartup;
@@ -206,6 +214,8 @@ namespace HotCornersApp {
                 ShowDesktop();
             } else if (index.Equals("Task View")) {
                 showTaskView();
+            } else if (index.Equals("Put Monitor to Sleep")) {
+                sleepMonitor();
             } else if (index.Equals("Keyboard Shortcut")) {
                 if (hotCornerIndex == 0) {
                     List<List<VirtualKeyCode>> resultantKeys = processKeyboardShortcutAsString(Properties.Settings.Default.topLeftShortcut);
@@ -394,6 +404,11 @@ namespace HotCornersApp {
 
         void LockWorkStationSafe() {
            LockWorkStation();
+        }
+
+        void sleepMonitor() {
+            IntPtr windowHandle = new WindowInteropHelper(this).Handle;
+            SendMessage(windowHandle, WM_SYSCOMMAND, (IntPtr)SC_MONITORPOWER, (IntPtr)2);
         }
         void showTaskView() {
             try {


### PR DESCRIPTION
I wanted to be able to use your HotCorners app to sleep my monitor (not lock it) so I added a little code to do that. 

I combined a couple items found on stackoverflow to do this:
http://stackoverflow.com/questions/1556182/finding-the-handle-to-a-wpf-window
http://stackoverflow.com/questions/3594465/send-display-to-sleep-mode-in-c-sharp